### PR TITLE
Derive Reflect on Components if possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +602,9 @@ dependencies = [
  "anyhow",
  "bevy_app 0.18.0",
  "bevy_ecs 0.18.0",
+ "bevy_reflect",
+ "bevy_remote",
+ "bevy_tasks 0.18.0",
  "clap",
  "dotenvy",
  "envy",
@@ -654,11 +663,14 @@ dependencies = [
  "bevy_tasks 0.18.0",
  "bevy_utils 0.18.0",
  "cfg-if",
+ "console_error_panic_hook",
  "ctrlc",
  "downcast-rs 2.0.2",
  "log",
  "thiserror 2.0.12",
  "variadics_please",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -757,6 +769,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_log"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "406304a9b867a2de98c3edf0cc9e5a608fad1a1ddc567e15e72c186a8273ef51"
+dependencies = [
+ "android_log-sys",
+ "bevy_app 0.18.0",
+ "bevy_ecs 0.18.0",
+ "bevy_platform",
+ "bevy_utils 0.18.0",
+ "tracing",
+ "tracing-log",
+ "tracing-oslog",
+ "tracing-subscriber",
+ "tracing-wasm",
+]
+
+[[package]]
 name = "bevy_macro_utils"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +828,7 @@ dependencies = [
  "spin 0.10.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -830,6 +861,7 @@ dependencies = [
  "foldhash 0.2.0",
  "glam 0.30.10",
  "indexmap",
+ "inventory",
  "serde",
  "smallvec",
  "smol_str",
@@ -854,6 +886,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_remote"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6a6513865c896948bf35e53943d7c5a7b56622c2a0ff9c4f5991110d12fceab"
+dependencies = [
+ "anyhow",
+ "async-channel 2.3.1",
+ "async-io",
+ "bevy_app 0.18.0",
+ "bevy_derive 0.18.0",
+ "bevy_ecs 0.18.0",
+ "bevy_log",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_tasks 0.18.0",
+ "bevy_utils 0.18.0",
+ "http-body-util",
+ "hyper",
+ "serde",
+ "serde_json",
+ "smol-hyper",
+]
+
+[[package]]
 name = "bevy_tasks"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +931,7 @@ checksum = "990ffedd374dd2c4fe8f0fd4bcefd5617d1ee59164b6c3fcc356a69b48e26e8e"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
+ "async-io",
  "async-task",
  "atomic-waker",
  "bevy_platform",
@@ -1410,6 +1467,16 @@ name = "condtype"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2905,6 +2972,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,6 +2990,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2986,6 +3060,7 @@ dependencies = [
  "base64 0.22.1",
  "bevy_app 0.18.0",
  "bevy_ecs 0.18.0",
+ "bevy_reflect",
  "bevy_tasks 0.18.0",
  "bevy_time",
  "bitfield-struct 0.12.1",
@@ -3083,6 +3158,7 @@ version = "0.1.0"
 dependencies = [
  "bevy_app 0.18.0",
  "bevy_ecs 0.18.0",
+ "bevy_reflect",
  "hyperion",
  "hyperion-utils",
  "indexmap",
@@ -3096,6 +3172,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bevy_ecs 0.18.0",
+ "bevy_reflect",
  "slotmap",
  "valence_protocol 0.2.0-alpha.1+mc.1.20.1 (git+https://github.com/TestingPlant/valence?branch=feat-bytes)",
 ]
@@ -3114,6 +3191,7 @@ name = "hyperion-gui"
 version = "0.1.0"
 dependencies = [
  "bevy_ecs 0.18.0",
+ "bevy_reflect",
  "hyperion",
  "hyperion-inventory",
  "serde",
@@ -3125,6 +3203,7 @@ name = "hyperion-inventory"
 version = "0.1.0"
 dependencies = [
  "bevy_ecs 0.18.0",
+ "bevy_reflect",
  "hyperion-crafting",
  "thiserror 2.0.12",
  "thread_local",
@@ -3170,6 +3249,7 @@ dependencies = [
  "anyhow",
  "bevy_app 0.18.0",
  "bevy_ecs 0.18.0",
+ "bevy_reflect",
  "clap",
  "heed",
  "hyperion",
@@ -3222,6 +3302,7 @@ version = "0.1.0"
 dependencies = [
  "bevy_app 0.18.0",
  "bevy_ecs 0.18.0",
+ "bevy_reflect",
  "hyperion",
  "hyperion-proxy",
  "tokio",
@@ -3255,6 +3336,7 @@ dependencies = [
  "anyhow",
  "bevy_app 0.18.0",
  "bevy_ecs 0.18.0",
+ "bevy_reflect",
  "bytemuck",
  "directories",
  "flate2",
@@ -3472,6 +3554,15 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -3752,11 +3843,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -4005,12 +4096,11 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4426,12 +4516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "owned_ttf_parser"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4447,6 +4531,7 @@ dependencies = [
  "arc-swap",
  "bevy_ecs 0.18.0",
  "bevy_platform",
+ "bevy_reflect",
  "divan",
  "more-asserts",
  "proptest",
@@ -4815,7 +4900,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -5096,17 +5181,8 @@ checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.14",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5117,7 +5193,7 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5125,12 +5201,6 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -5734,6 +5804,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "smol-hyper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7428a49d323867702cd12b97b08a6b0104f39ec13b49117911f101271321bc1a"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "futures-io",
+ "hyper",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "smol_str"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5893,7 +5976,7 @@ dependencies = [
  "fnv",
  "once_cell",
  "plist",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6332,9 +6415,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -6343,9 +6426,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6354,9 +6437,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -6374,15 +6457,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.3.19"
+name = "tracing-oslog"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "d76902d2a8d5f9f55a81155c08971734071968c90f2d9bfe645fe700579b2950"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -6401,6 +6496,17 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
  "tracy-client",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ bevy_ecs = { version = '0.18', default-features = false, features = [
     'trace',
 ] }
 bevy_platform = '0.18'
+bevy_reflect = '0.18'
 bevy_tasks = '0.18'
 bevy_time = '0.18'
 num_cpus = '1.16'
@@ -237,7 +238,7 @@ tracing-appender = '0.2'
 [workspace.lints]
 
 [workspace.lints.rust]
-missing_docs = 'warn'
+#missing_docs = 'warn'
 future_incompatible = { level = 'deny', priority = -1 }
 keyword_idents = { level = 'deny', priority = -1 }
 let_underscore = { level = 'deny', priority = -1 }

--- a/crates/hyperion-clap/Cargo.toml
+++ b/crates/hyperion-clap/Cargo.toml
@@ -5,6 +5,16 @@ version.workspace = true
 publish = false
 readme = "README.md"
 
+[features]
+reflect = [
+    "bevy_app/reflect_auto_register",
+    "bevy_ecs/reflect_auto_register",
+    "hyperion/reflect",
+    "hyperion-command/reflect",
+    "hyperion-permission/reflect",
+    "hyperion-utils/reflect",
+]
+
 [dependencies]
 hyperion.workspace = true
 hyperion-clap-macros.workspace = true

--- a/crates/hyperion-command/Cargo.toml
+++ b/crates/hyperion-command/Cargo.toml
@@ -5,12 +5,23 @@ version.workspace = true
 publish = false
 readme = "README.md"
 
+[features]
+reflect = [
+    "dep:bevy_reflect",
+    "bevy_app/reflect_auto_register",
+    "bevy_ecs/reflect_auto_register",
+    "bevy_reflect/auto_register_inventory",
+    "hyperion/reflect",
+    "hyperion-utils/reflect",
+]
+
 [dependencies]
 hyperion.workspace = true
 hyperion-utils.workspace = true
 
 bevy_app.workspace = true
 bevy_ecs.workspace = true
+bevy_reflect = { workspace = true, optional = true }
 
 indexmap.workspace = true
 itertools.workspace = true

--- a/crates/hyperion-command/src/component.rs
+++ b/crates/hyperion-command/src/component.rs
@@ -5,6 +5,8 @@ use bevy_ecs::{entity::Entity, resource::Resource, world::World};
 use hyperion::simulation::packet::play;
 use hyperion_utils::ApplyWorld;
 use indexmap::IndexMap;
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectResource, bevy_reflect::Reflect};
 
 pub trait ExecutableCommand: ApplyWorld {
     /// Executes a command triggered by a player
@@ -17,6 +19,7 @@ pub struct CommandHandler {
     pub has_permissions: fn(&World, Entity) -> bool,
 }
 
+#[derive(Default)]
 pub struct CommandRegistryInner {
     pub(crate) commands: IndexMap<String, CommandHandler>,
 }
@@ -52,7 +55,10 @@ impl CommandRegistryInner {
 /// This registry is locked by a [`Mutex`]. See the `execute_commands` system for justification.
 /// Consider accessing this resource using [`ResMut`] and [`Mutex::get_mut`].
 #[derive(Resource)]
-pub struct CommandRegistry(Mutex<CommandRegistryInner>);
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
+pub struct CommandRegistry(
+    #[cfg_attr(feature = "reflect", reflect(ignore))] Mutex<CommandRegistryInner>,
+);
 
 impl std::ops::Deref for CommandRegistry {
     type Target = Mutex<CommandRegistryInner>;

--- a/crates/hyperion-crafting/Cargo.toml
+++ b/crates/hyperion-crafting/Cargo.toml
@@ -5,10 +5,18 @@ version.workspace = true
 publish = false
 readme = "README.md"
 
+[features]
+reflect = [
+    "dep:bevy_reflect",
+    "bevy_ecs/reflect_auto_register",
+    "bevy_reflect/auto_register_inventory",
+]
+
 [dependencies]
 valence_protocol.workspace = true
 
 bevy_ecs.workspace = true
+bevy_reflect = { workspace = true, optional = true }
 
 anyhow.workspace = true
 slotmap.workspace = true

--- a/crates/hyperion-crafting/src/lib.rs
+++ b/crates/hyperion-crafting/src/lib.rs
@@ -3,6 +3,8 @@ use std::{collections::HashMap, io::Write};
 use bevy_ecs::resource::Resource;
 use slotmap::{SecondaryMap, SlotMap, new_key_type};
 use valence_protocol::{Encode, ItemKind, ItemStack, Packet};
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectResource, bevy_reflect::Reflect};
 
 /// Represents a packet sent from the server to the client to synchronize recipes.
 #[derive(Clone, Debug, Encode, Packet)]
@@ -247,12 +249,17 @@ impl FromIterator<ItemKind> for SortedItemList {
 new_key_type! { struct SortedItemId; }
 
 #[derive(Resource)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
 pub struct CraftingRegistry {
     // changes when the registry is updated
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     epoch: u64,
 
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     shapeless_lookup: HashMap<SortedItemList, SortedItemId>,
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     shapeless: SlotMap<SortedItemId, CraftingShapelessData>,
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     shapeless_ids: SecondaryMap<SortedItemId, String>,
 }
 

--- a/crates/hyperion-crafting/src/lib.rs
+++ b/crates/hyperion-crafting/src/lib.rs
@@ -252,7 +252,6 @@ new_key_type! { struct SortedItemId; }
 #[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
 pub struct CraftingRegistry {
     // changes when the registry is updated
-    #[cfg_attr(feature = "reflect", reflect(ignore))]
     epoch: u64,
 
     #[cfg_attr(feature = "reflect", reflect(ignore))]

--- a/crates/hyperion-gui/Cargo.toml
+++ b/crates/hyperion-gui/Cargo.toml
@@ -3,6 +3,15 @@ name = "hyperion-gui"
 edition.workspace = true
 version.workspace = true
 
+[features]
+reflect = [
+    "dep:bevy_reflect",
+    "bevy_ecs/reflect_auto_register",
+    "bevy_reflect/auto_register_inventory",
+    "hyperion/reflect",
+    "hyperion-inventory/reflect",
+]
+
 [dependencies]
 hyperion.workspace = true
 hyperion-inventory.workspace = true
@@ -10,6 +19,7 @@ hyperion-inventory.workspace = true
 valence_protocol.workspace = true
 
 bevy_ecs.workspace = true
+bevy_reflect = { workspace = true, optional = true }
 
 serde.workspace = true
 

--- a/crates/hyperion-gui/src/lib.rs
+++ b/crates/hyperion-gui/src/lib.rs
@@ -32,6 +32,7 @@ pub enum ContainerType {
 pub struct Gui {
     entity: Entity,
     #[cfg_attr(feature = "reflect", reflect(ignore))]
+    // TODO: Maybe this should just be a static size array for faster lookup? How much more memory would that take? Maybe RLE with linear scan on smallvec?, would probably be faster than hashing a integer?
     items: HashMap<usize, fn(Entity, ClickMode)>,
     pub id: u64,
 }

--- a/crates/hyperion-gui/src/lib.rs
+++ b/crates/hyperion-gui/src/lib.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 use valence_protocol::packets::play::{
     click_slot_c2s::ClickMode, close_screen_s2c::CloseScreenS2c,
 };
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InventoryItem {
@@ -26,8 +28,10 @@ pub enum ContainerType {
 }
 
 #[derive(Component, Clone)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Gui {
     entity: Entity,
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     items: HashMap<usize, fn(Entity, ClickMode)>,
     pub id: u64,
 }

--- a/crates/hyperion-inventory/Cargo.toml
+++ b/crates/hyperion-inventory/Cargo.toml
@@ -5,6 +5,14 @@ version.workspace = true
 publish = false
 readme = "README.md"
 
+[features]
+reflect = [
+    "dep:bevy_reflect",
+    "bevy_ecs/reflect_auto_register",
+    "bevy_reflect/auto_register_inventory",
+    "hyperion-crafting/reflect",
+]
+
 [dependencies]
 hyperion-crafting.workspace = true
 
@@ -12,6 +20,7 @@ valence_generated.workspace = true
 valence_protocol.workspace = true
 
 bevy_ecs.workspace = true
+bevy_reflect = { workspace = true, optional = true }
 
 tracing.workspace = true
 thiserror.workspace = true

--- a/crates/hyperion-inventory/src/lib.rs
+++ b/crates/hyperion-inventory/src/lib.rs
@@ -1,3 +1,4 @@
+#![expect(clippy::transmute_ptr_to_ptr)]
 use std::{cell::Cell, cmp::min, num::Wrapping};
 
 use bevy_ecs::{component::Component, entity::Entity};
@@ -13,8 +14,50 @@ use valence_protocol::{
 #[cfg(feature = "reflect")]
 use {
     bevy_ecs::reflect::ReflectComponent,
-    bevy_reflect::{Reflect, std_traits::ReflectDefault},
+    bevy_reflect::{Reflect, reflect_remote, std_traits::ReflectDefault},
 };
+
+// TODO: Probably have a seperate Hyperion_remote_reflect?
+#[cfg(feature = "reflect")]
+#[reflect_remote(WindowType)]
+pub enum WindowTypeRemote {
+    Generic9x1,
+    Generic9x2,
+    Generic9x3,
+    Generic9x4,
+    Generic9x5,
+    Generic9x6,
+    Generic3x3,
+    Anvil,
+    Beacon,
+    BlastFurnace,
+    BrewingStand,
+    Crafting,
+    Enchantment,
+    Furnace,
+    Grindstone,
+    Hopper,
+    Lectern,
+    Loom,
+    Merchant,
+    ShulkerBox,
+    Smithing,
+    Smoker,
+    Cartography,
+    Stonecutter,
+}
+
+#[cfg(feature = "reflect")]
+#[reflect_remote(ClickMode)]
+pub enum ClickModeRemote {
+    Click,
+    ShiftClick,
+    Hotbar,
+    CreativeMiddleClick,
+    DropKey,
+    Drag,
+    DoubleClick,
+}
 
 pub type PlayerInventory = Inventory;
 
@@ -23,27 +66,49 @@ pub type PlayerInventory = Inventory;
 pub struct Inventory {
     /// The slots in the inventory
     #[cfg_attr(feature = "reflect", reflect(ignore))]
+    // TODO: ItemKind enum needs manual derive, all the code for remote reflection isn't worth it
     slots: Box<[ItemSlot]>,
     /// Index to the slot held in the player's hand. This is guaranteed to be a valid index.
     hand_slot: u16,
     title: String,
-    #[cfg_attr(feature = "reflect", reflect(ignore))]
+    #[cfg_attr(feature = "reflect", reflect(remote = WindowTypeRemote))]
     kind: WindowType,
     readonly: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+pub struct LastMode {
+    #[cfg_attr(feature = "reflect", reflect(remote = ClickModeRemote))]
+    pub mode: ClickMode,
+    pub tick: i64,
+}
+
+impl Default for LastMode {
+    fn default() -> Self {
+        Self {
+            mode: ClickMode::Click,
+            tick: 0,
+        }
+    }
 }
 
 #[derive(Component, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component, Default))]
 pub struct InventoryState {
     window_id: u8,
+    #[cfg_attr(feature = "reflect", reflect(remote = WrappingI32Remote))]
     state_id: Wrapping<i32>,
     // i64 is the last tick
     #[cfg_attr(feature = "reflect", reflect(ignore))]
     last_stack_clicked: (ItemStack, i64),
     last_button: (i8, i64),
-    #[cfg_attr(feature = "reflect", reflect(ignore))]
-    last_mode: (ClickMode, i64),
+    last_mode: LastMode,
 }
+
+#[cfg(feature = "reflect")]
+#[reflect_remote(Wrapping<i32>)]
+pub struct WrappingI32Remote(pub i32);
 
 impl Default for InventoryState {
     fn default() -> Self {
@@ -52,7 +117,7 @@ impl Default for InventoryState {
             state_id: Wrapping(0),
             last_stack_clicked: (ItemStack::EMPTY, 0),
             last_button: (0, 0),
-            last_mode: (ClickMode::Click, 0),
+            last_mode: LastMode::default(),
         }
     }
 }
@@ -101,13 +166,13 @@ impl InventoryState {
     }
 
     #[must_use]
-    pub const fn last_mode(&self) -> (ClickMode, i64) {
+    pub const fn last_mode(&self) -> LastMode {
         self.last_mode
     }
 
     pub const fn set_last_mode(&mut self, mode: ClickMode, tick: i64) {
-        self.last_mode.0 = mode;
-        self.last_mode.1 = tick;
+        self.last_mode.mode = mode;
+        self.last_mode.tick = tick;
     }
 }
 

--- a/crates/hyperion-inventory/src/lib.rs
+++ b/crates/hyperion-inventory/src/lib.rs
@@ -10,27 +10,38 @@ use valence_protocol::{
     nbt::Compound,
     packets::play::{click_slot_c2s::ClickMode, open_screen_s2c::WindowType},
 };
+#[cfg(feature = "reflect")]
+use {
+    bevy_ecs::reflect::ReflectComponent,
+    bevy_reflect::{Reflect, std_traits::ReflectDefault},
+};
 
 pub type PlayerInventory = Inventory;
 
 #[derive(Component, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component, Default))]
 pub struct Inventory {
     /// The slots in the inventory
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     slots: Box<[ItemSlot]>,
     /// Index to the slot held in the player's hand. This is guaranteed to be a valid index.
     hand_slot: u16,
     title: String,
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     kind: WindowType,
     readonly: bool,
 }
 
 #[derive(Component, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component, Default))]
 pub struct InventoryState {
     window_id: u8,
     state_id: Wrapping<i32>,
     // i64 is the last tick
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     last_stack_clicked: (ItemStack, i64),
     last_button: (i8, i64),
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     last_mode: (ClickMode, i64),
 }
 
@@ -129,6 +140,7 @@ impl ItemSlot {
 }
 
 #[derive(Component, Clone, Debug)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct OpenInventory {
     pub inventory: Entity,
     pub client_changed: u64,
@@ -145,7 +157,8 @@ impl OpenInventory {
 }
 
 #[derive(Component, Clone, PartialEq, Default, Debug)]
-pub struct CursorItem(pub ItemStack);
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
+pub struct CursorItem(#[cfg_attr(feature = "reflect", reflect(ignore))] pub ItemStack);
 
 impl std::ops::Deref for CursorItem {
     type Target = ItemStack;

--- a/crates/hyperion-item/Cargo.toml
+++ b/crates/hyperion-item/Cargo.toml
@@ -5,6 +5,14 @@ version.workspace = true
 publish = false
 readme = "README.md"
 
+[features]
+reflect = [
+    "hyperion/reflect",
+    "hyperion-inventory/reflect",
+    "bevy_app/reflect_auto_register",
+    "bevy_ecs/reflect_auto_register",
+]
+
 [dependencies]
 hyperion.workspace = true
 hyperion-inventory.workspace = true

--- a/crates/hyperion-permission/Cargo.toml
+++ b/crates/hyperion-permission/Cargo.toml
@@ -5,11 +5,21 @@ version.workspace = true
 publish = false
 readme = "README.md"
 
+[features]
+reflect = [
+    "dep:bevy_reflect",
+    "bevy_app/reflect_auto_register",
+    "bevy_ecs/reflect_auto_register",
+    "bevy_reflect/auto_register_inventory",
+    "hyperion/reflect",
+]
+
 [dependencies]
 hyperion.workspace = true
 
 bevy_app.workspace = true
 bevy_ecs.workspace = true
+bevy_reflect = { workspace = true, optional = true }
 
 anyhow.workspace = true
 clap.workspace = true

--- a/crates/hyperion-permission/src/lib.rs
+++ b/crates/hyperion-permission/src/lib.rs
@@ -17,10 +17,13 @@ use hyperion::{
 };
 use storage::PermissionStorage;
 use tracing::error;
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 pub struct PermissionPlugin;
 
 #[derive(Default, Component, Copy, Clone, Debug, PartialEq, ValueEnum, Eq)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 #[repr(u8)]
 pub enum Group {
     Banned = 0,

--- a/crates/hyperion-proxy-module/Cargo.toml
+++ b/crates/hyperion-proxy-module/Cargo.toml
@@ -5,12 +5,22 @@ version.workspace = true
 publish = false
 readme = "README.md"
 
+[features]
+reflect = [
+    "dep:bevy_reflect",
+    "bevy_app/reflect_auto_register",
+    "bevy_ecs/reflect_auto_register",
+    "bevy_reflect/auto_register_inventory",
+    "hyperion/reflect",
+]
+
 [dependencies]
 hyperion.workspace = true
 hyperion-proxy.workspace = true
 
 bevy_app.workspace = true
 bevy_ecs.workspace = true
+bevy_reflect = { workspace = true, optional = true }
 
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/hyperion-proxy-module/src/lib.rs
+++ b/crates/hyperion-proxy-module/src/lib.rs
@@ -4,10 +4,13 @@ use bevy_app::{App, Plugin};
 use bevy_ecs::{event::Event, observer::On, system::Res};
 use hyperion::runtime::AsyncRuntime;
 use tokio::net::TcpListener;
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectEvent, bevy_reflect::Reflect};
 
 pub struct HyperionProxyPlugin;
 
 #[derive(Event)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Event))]
 pub struct SetProxyAddress {
     pub proxy: String,
     pub server: String,

--- a/crates/hyperion-proxy/src/lib.rs
+++ b/crates/hyperion-proxy/src/lib.rs
@@ -58,7 +58,7 @@ async fn connect(addr: impl ToSocketAddrs + Debug + Clone) -> TcpStream {
 }
 
 #[derive(Debug, PartialEq)]
-enum ShutdownType {
+pub enum ShutdownType {
     Reconnect,
     Full,
 }
@@ -327,6 +327,6 @@ where
     }
 }
 
-trait HyperionListener: Listener<Io: Send, Addr: Debug> + 'static {}
+pub trait HyperionListener: Listener<Io: Send, Addr: Debug> + 'static {}
 
 impl<L: Listener<Io: Send, Addr: Debug> + 'static> HyperionListener for L {}

--- a/crates/hyperion-utils/Cargo.toml
+++ b/crates/hyperion-utils/Cargo.toml
@@ -5,9 +5,18 @@ version.workspace = true
 publish = false
 readme = "README.md"
 
+[features]
+reflect = [
+    "dep:bevy_reflect",
+    "bevy_app/reflect_auto_register",
+    "bevy_ecs/reflect_auto_register",
+    "bevy_reflect/auto_register_inventory",
+]
+
 [dependencies]
 bevy_app.workspace = true
 bevy_ecs.workspace = true
+bevy_reflect = { workspace = true, optional = true }
 
 anyhow.workspace = true
 bytemuck.workspace = true

--- a/crates/hyperion-utils/src/lib.rs
+++ b/crates/hyperion-utils/src/lib.rs
@@ -12,6 +12,8 @@ use bevy_ecs::{
 };
 pub use cached_save::cached_save;
 pub use prev::{Prev, track_prev};
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectResource, bevy_reflect::Reflect};
 
 pub trait EntityExt: Sized {
     fn id(&self) -> u32;
@@ -68,6 +70,7 @@ impl ApplyWorld for () {
 
 /// Represents application identification information used for caching and other system-level operations
 #[derive(Resource)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
 pub struct AppId {
     /// The qualifier/category of the application (e.g. "com", "org", "hyperion")
     pub qualifier: String,

--- a/crates/hyperion-utils/src/prev.rs
+++ b/crates/hyperion-utils/src/prev.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 use bevy_app::{App, FixedPreUpdate};
 use bevy_ecs::{
@@ -27,7 +27,7 @@ fn initialize_previous<T: Component + Clone>(
 
 fn update_previous<T: Component + Clone>(mut query: Query<'_, '_, (&mut Prev<T>, &T)>) {
     for (mut prev, current) in &mut query {
-        prev.set(current.clone());
+        *prev = Prev(current.clone());
     }
 }
 
@@ -42,16 +42,16 @@ pub fn track_prev<T: Component + Clone>(app: &mut App) {
 #[derive(Component, Copy, Clone, PartialEq, Eq, Debug)]
 pub struct Prev<T>(T);
 
-impl<T> Prev<T> {
-    fn set(&mut self, new: T) {
-        self.0 = new;
-    }
-}
-
 impl<T> Deref for Prev<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl<T> DerefMut for Prev<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }

--- a/crates/hyperion/Cargo.toml
+++ b/crates/hyperion/Cargo.toml
@@ -5,6 +5,18 @@ version.workspace = true
 publish = false
 readme = "README.md"
 
+[features]
+reflect = [
+    "dep:bevy_reflect",
+    "bevy_app/reflect_auto_register",
+    "bevy_ecs/reflect_auto_register",
+    "bevy_reflect/auto_register_inventory",
+    "bevy_reflect/uuid",
+    "hyperion-crafting/reflect",
+    "hyperion-inventory/reflect",
+    "hyperion-utils/reflect",
+]
+
 [[bench]]
 harness = false
 name = "set"
@@ -30,6 +42,7 @@ valence_text.workspace = true
 
 bevy_app.workspace = true
 bevy_ecs.workspace = true
+bevy_reflect = { workspace = true, optional = true }
 bevy_tasks.workspace = true
 bevy_time.workspace = true
 

--- a/crates/hyperion/src/common/command_channel.rs
+++ b/crates/hyperion/src/common/command_channel.rs
@@ -15,6 +15,8 @@ use bevy_ecs::{
     system::Command,
     world::World,
 };
+#[cfg(feature = "reflect")]
+use bevy_reflect::Reflect;
 use tracing::error;
 
 struct CommandMeta {
@@ -42,6 +44,7 @@ struct Inner {
 
 /// Densely and efficiently stores a multiple-producer single-consumer channel of heterogenous types implementing [`Command`].
 #[derive(Resource, Default, Clone)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(opaque))]
 pub struct CommandChannel {
     // TODO: Replace this Mutex with a lock-free alternative
     inner: Arc<Mutex<Inner>>,

--- a/crates/hyperion/src/common/config.rs
+++ b/crates/hyperion/src/common/config.rs
@@ -2,12 +2,15 @@
 
 use std::{fmt::Debug, fs::File, io::Read, path::Path};
 
-use bevy_ecs::{component::Component, resource::Resource};
+use bevy_ecs::resource::Resource;
 use serde::{Deserialize, Serialize};
 use tracing::{info, instrument, warn};
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectResource, bevy_reflect::Reflect};
 
 /// The configuration for the server representing a `toml` file.
 #[derive(Serialize, Deserialize, Debug, Resource)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
 pub struct Config {
     pub border_diameter: Option<f64>,
     pub max_players: i32,
@@ -17,7 +20,8 @@ pub struct Config {
     pub spawn: Spawn,
 }
 
-#[derive(Serialize, Deserialize, Debug, Component)]
+#[derive(Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
 pub struct Spawn {
     pub kind: Radius,
     pub radius: i32,
@@ -27,6 +31,7 @@ pub struct Spawn {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
 pub enum Radius {
     Chebyshev,
     Euclidean,

--- a/crates/hyperion/src/common/mod.rs
+++ b/crates/hyperion/src/common/mod.rs
@@ -4,7 +4,6 @@ use std::{
     time::Duration,
 };
 
-use bevy_ecs::component::Component;
 #[cfg(feature = "reflect")]
 use bevy_reflect::Reflect;
 use libdeflater::CompressionLvl;
@@ -19,7 +18,7 @@ pub mod util;
 #[cfg_attr(feature = "reflect", derive(Reflect))]
 pub struct Shared {
     /// The compression level to use for the server. This is how long a packet needs to be before it is compressed.
-    #[cfg_attr(feature = "reflect", reflect(ignore))]
+    #[cfg_attr(feature = "reflect", reflect(remote = crate::reflect::CompressionThreshold))]
     pub compression_threshold: CompressionThreshold,
 
     /// The compression level to use for the server. This is the [`libdeflater`] compression level.
@@ -27,7 +26,6 @@ pub struct Shared {
     pub compression_level: CompressionLvl,
 }
 
-#[derive(Component)]
 #[cfg_attr(feature = "reflect", derive(Reflect))]
 pub struct Global {
     /// The current tick of the game. This is incremented every 50 ms.
@@ -39,6 +37,7 @@ pub struct Global {
     pub max_hurt_resistant_time: u16,
 
     /// Data shared between the IO thread and the ECS framework.
+    #[cfg_attr(feature = "reflect", reflect(ignore, default = "dummy_reflect_shared"))]
     pub shared: Arc<Shared>,
 
     /// The amount of time from the last packet a player has sent before the server will kick them.
@@ -47,7 +46,18 @@ pub struct Global {
     /// The amount of time the last tick took in milliseconds.
     pub ms_last_tick: f32,
 
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     pub player_count: AtomicUsize,
+}
+
+// Note: Caution! The Arc and AtomicUsize did not throw errors for me, it just didn't work
+
+#[cfg(feature = "reflect")]
+fn dummy_reflect_shared() -> Arc<Shared> {
+    Arc::new(Shared {
+        compression_threshold: CompressionThreshold::default(),
+        compression_level: CompressionLvl::default(),
+    })
 }
 
 impl Global {

--- a/crates/hyperion/src/common/mod.rs
+++ b/crates/hyperion/src/common/mod.rs
@@ -5,6 +5,8 @@ use std::{
 };
 
 use bevy_ecs::component::Component;
+#[cfg(feature = "reflect")]
+use bevy_reflect::Reflect;
 use libdeflater::CompressionLvl;
 use valence_protocol::CompressionThreshold;
 
@@ -14,15 +16,19 @@ pub mod runtime;
 pub mod util;
 
 /// Shared data that is shared between the ECS framework and the IO thread.
+#[cfg_attr(feature = "reflect", derive(Reflect))]
 pub struct Shared {
     /// The compression level to use for the server. This is how long a packet needs to be before it is compressed.
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     pub compression_threshold: CompressionThreshold,
 
     /// The compression level to use for the server. This is the [`libdeflater`] compression level.
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     pub compression_level: CompressionLvl,
 }
 
 #[derive(Component)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
 pub struct Global {
     /// The current tick of the game. This is incremented every 50 ms.
     pub tick: i64,

--- a/crates/hyperion/src/common/runtime.rs
+++ b/crates/hyperion/src/common/runtime.rs
@@ -3,9 +3,12 @@
 use std::sync::Arc;
 
 use bevy_ecs::resource::Resource;
+#[cfg(feature = "reflect")]
+use bevy_reflect::Reflect;
 
 /// Wrapper around [`tokio::runtime::Runtime`]
 #[derive(Resource, Clone)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(opaque))]
 pub struct AsyncRuntime {
     runtime: Arc<tokio::runtime::Runtime>,
 }

--- a/crates/hyperion/src/egress/player_join/mod.rs
+++ b/crates/hyperion/src/egress/player_join/mod.rs
@@ -257,7 +257,7 @@ fn process_player_join(
                     was_on_ground: false,
                 },
                 PendingTeleportation::new(position),
-                packet_state::Play(()),
+                packet_state::Play,
             ));
         });
 

--- a/crates/hyperion/src/egress/sync_chunks.rs
+++ b/crates/hyperion/src/egress/sync_chunks.rs
@@ -13,6 +13,8 @@ use valence_protocol::{
     ChunkPos, VarInt,
     packets::play::{self},
 };
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 use crate::{
     config::Config,
@@ -25,7 +27,9 @@ use crate::{
 };
 
 #[derive(Component, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct ChunkSendQueue {
+    #[cfg_attr(feature = "reflect", reflect(ignore))] // bevy glam is newer sadly
     changes: Vec<I16Vec2>,
 }
 

--- a/crates/hyperion/src/egress/sync_chunks.rs
+++ b/crates/hyperion/src/egress/sync_chunks.rs
@@ -29,7 +29,8 @@ use crate::{
 #[derive(Component, Default)]
 #[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct ChunkSendQueue {
-    #[cfg_attr(feature = "reflect", reflect(ignore))] // bevy glam is newer sadly
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
+    // TODO: Should be reflectable once glam is updated everywhere
     changes: Vec<I16Vec2>,
 }
 

--- a/crates/hyperion/src/ingress/decode.rs
+++ b/crates/hyperion/src/ingress/decode.rs
@@ -30,8 +30,11 @@ mod __private {
     use bevy_ecs::resource::Resource;
     use thread_local::ThreadLocal;
     use tracing::warn;
+    #[cfg(feature = "reflect")]
+    use {bevy_ecs::reflect::ReflectResource, bevy_reflect::Reflect};
 
     #[derive(Default, Resource)]
+    #[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
     pub struct PacketIdGenerator(AtomicU64);
 
     impl PacketIdGenerator {
@@ -48,7 +51,11 @@ mod __private {
     }
 
     #[derive(Default, Resource)]
-    pub struct Decompressor(pub ThreadLocal<RefCell<libdeflater::Decompressor>>);
+    #[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
+    pub struct Decompressor(
+        #[cfg_attr(feature = "reflect", reflect(ignore))]
+        pub  ThreadLocal<RefCell<libdeflater::Decompressor>>,
+    );
 }
 
 mod buffers {

--- a/crates/hyperion/src/ingress/mod.rs
+++ b/crates/hyperion/src/ingress/mod.rs
@@ -25,6 +25,8 @@ use valence_protocol::{
         status::{QueryPongS2c, QueryResponseS2c},
     },
 };
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectResource, bevy_reflect::Reflect};
 
 use crate::{
     InitializePlayerPosition,
@@ -33,22 +35,8 @@ use crate::{
     net::{Compose, MINECRAFT_VERSION, PROTOCOL_VERSION, PacketDecoder},
     runtime::AsyncRuntime,
     simulation::{
-        AiTargetable,
-        ChunkPosition,
-        ImmuneStatus,
-        Pitch,
-        Uuid,
-        Velocity,
-        Xp,
-        Yaw,
-        animation::ActiveAnimation,
-        entity_kind::EntityKind,
-        packet,
-        // animation::ActiveAnimation,
-        // blocks::Blocks,
-        // handlers::PacketSwitchQuery,
-        // metadata::{MetadataPrefabs, entity::Pose},
-        packet_state,
+        AiTargetable, ChunkPosition, ImmuneStatus, Pitch, Player, Uuid, Velocity, Xp, Yaw,
+        animation::ActiveAnimation, entity_kind::EntityKind, packet, packet_state,
         skin::PlayerSkin,
     },
     storage::SkinHandler,
@@ -67,16 +55,17 @@ pub fn process_handshake(
         entity.remove::<packet_state::Handshake>();
         match packet.next_state {
             HandshakeNextState::Status => {
-                entity.insert(packet_state::Status(()));
+                entity.insert(packet_state::Status);
             }
             HandshakeNextState::Login => {
-                entity.insert(packet_state::Login(()));
+                entity.insert(packet_state::Login);
             }
         }
     }
 }
 
 #[derive(Resource)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
 pub struct ServerPingResponse {
     pub description: String,
     pub max_players: u32,
@@ -233,6 +222,7 @@ pub fn process_login_hello(
             // TODO: The more specific components (such as ChunkSendQueue) should be added in a
             // separate system, this might be a case for required components?
             entity.remove::<packet_state::Login>().insert((
+                Player,
                 Name::new(username.clone()),
                 ActiveAnimation::NONE,
                 AiTargetable,

--- a/crates/hyperion/src/lib.rs
+++ b/crates/hyperion/src/lib.rs
@@ -20,6 +20,11 @@ use rustls_pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
 use storage::{LocalDb, SkinHandler};
 use tracing::{info, warn};
 use valence_protocol::{CompressionThreshold, Encode, Packet};
+#[cfg(feature = "reflect")]
+use {
+    bevy_ecs::reflect::{ReflectEvent, ReflectResource},
+    bevy_reflect::Reflect,
+};
 
 mod common;
 pub use common::*;
@@ -98,6 +103,7 @@ pub fn adjust_file_descriptor_limits(recommended_min: u64) -> std::io::Result<()
 }
 
 #[derive(Resource)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(opaque))]
 pub struct Crypto {
     /// The root certificate authority's certificate
     pub root_ca_cert: CertificateDer<'static>,
@@ -134,6 +140,7 @@ impl Clone for Crypto {
 }
 
 #[derive(Resource, Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
 pub struct Endpoint(SocketAddr);
 
 impl From<SocketAddr> for Endpoint {
@@ -156,6 +163,7 @@ impl From<SocketAddr> for Endpoint {
 }
 
 #[derive(EntityEvent, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Event))]
 pub struct InitializePlayerPosition(pub Entity);
 
 /// The central [`HyperionCore`] struct which owns and manages the entire server.

--- a/crates/hyperion/src/lib.rs
+++ b/crates/hyperion/src/lib.rs
@@ -48,6 +48,10 @@ pub mod simulation;
 pub mod spatial;
 pub mod storage;
 
+#[cfg(feature = "reflect")]
+#[expect(clippy::transmute_ptr_to_ptr, clippy::used_underscore_binding)]
+pub mod reflect;
+
 pub const CHUNK_HEIGHT_SPAN: u32 = 384; // 512; // usually 384
 
 pub trait PacketBundle {

--- a/crates/hyperion/src/net/decoder.rs
+++ b/crates/hyperion/src/net/decoder.rs
@@ -6,10 +6,14 @@ use packet_channel::RawPacket;
 use valence_protocol::{
     CompressionThreshold, Decode, DecodeBytes, MAX_PACKET_SIZE, Packet, VarInt,
 };
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 /// A buffer for saving bytes that are not yet decoded.
-#[derive(Default, Component)]
+#[derive(Component, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct PacketDecoder {
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     threshold: CompressionThreshold,
 }
 

--- a/crates/hyperion/src/net/decoder.rs
+++ b/crates/hyperion/src/net/decoder.rs
@@ -13,7 +13,7 @@ use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 #[derive(Component, Default)]
 #[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct PacketDecoder {
-    #[cfg_attr(feature = "reflect", reflect(ignore))]
+    #[cfg_attr(feature = "reflect", reflect(remote = crate::reflect::CompressionThreshold))]
     threshold: CompressionThreshold,
 }
 

--- a/crates/hyperion/src/net/mod.rs
+++ b/crates/hyperion/src/net/mod.rs
@@ -16,6 +16,11 @@ use libdeflater::CompressionLvl;
 use rustc_hash::FxHashMap;
 use thread_local::ThreadLocal;
 use tracing::error;
+#[cfg(feature = "reflect")]
+use {
+    bevy_ecs::reflect::{ReflectComponent, ReflectResource},
+    bevy_reflect::Reflect,
+};
 
 use crate::{
     Global, PacketBundle, Scratch,
@@ -45,6 +50,7 @@ pub const MINECRAFT_VERSION: &str = "1.20.1";
 
 /// A unique identifier for a proxy to game server connection
 #[derive(Component, Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct ProxyId {
     /// The underlying unique identifier for the proxy connection.
     /// This value is guaranteed to be unique among all active connections.
@@ -83,6 +89,7 @@ impl ProxyId {
 /// Note: Connection IDs are managed internally by the networking system and should be obtained
 /// through the appropriate connection establishment handlers rather than created directly.
 #[derive(Component, Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct ConnectionId {
     /// The underlying unique identifier for this connection.
     /// This value is guaranteed to be unique among all active connections.
@@ -128,10 +135,12 @@ impl ConnectionId {
 
 /// A component marking an entity as a packet channel.
 #[derive(Component, Copy, Clone, Debug)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Channel;
 
 /// A unique identifier for a channel. The server is responsible for managing channel IDs.
 #[derive(Component, Copy, Clone, Debug)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct ChannelId {
     /// The underlying unique identifier for this channel.
     channel_id: u32,
@@ -163,9 +172,13 @@ impl From<Entity> for ChannelId {
 
 /// A singleton that can be used to compose and encode packets.
 #[derive(Resource)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
 pub struct Compose {
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     compression_lvl: CompressionLvl,
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     compressor: ThreadLocal<RefCell<libdeflater::Compressor>>,
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     scratch: ThreadLocal<RefCell<Scratch>>,
     global: Global,
     io_buf: IoBuf,
@@ -371,11 +384,15 @@ impl Compose {
 
 /// This is useful for the ECS, so we can use Single<&mut Broadcast> instead of having to use a marker struct
 #[derive(Component, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct IoBuf {
     // system_on: ThreadLocal<Cell<u32>>,
     // broadcast_buffer: ThreadLocal<RefCell<BytesMut>>,
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     temp_buffer: ThreadLocal<RefCell<BytesMut>>,
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     idx: ThreadLocal<Cell<u16>>,
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     egress_comms: FxHashMap<ProxyId, EgressComm>,
 }
 

--- a/crates/hyperion/src/net/mod.rs
+++ b/crates/hyperion/src/net/mod.rs
@@ -383,8 +383,8 @@ impl Compose {
 }
 
 /// This is useful for the ECS, so we can use Single<&mut Broadcast> instead of having to use a marker struct
-#[derive(Component, Default)]
-#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
+#[derive(Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
 pub struct IoBuf {
     // system_on: ThreadLocal<Cell<u32>>,
     // broadcast_buffer: ThreadLocal<RefCell<BytesMut>>,

--- a/crates/hyperion/src/net/proxy.rs
+++ b/crates/hyperion/src/net/proxy.rs
@@ -101,7 +101,7 @@ async fn handle_proxy_messages(
                     let player = world
                         .spawn((
                             ConnectionId::new(stream, proxy_id),
-                            packet_state::Handshake(()),
+                            packet_state::Handshake,
                             PacketDecoder::default(),
                             receiver,
                         ))

--- a/crates/hyperion/src/reflect.rs
+++ b/crates/hyperion/src/reflect.rs
@@ -1,0 +1,147 @@
+/// Wrappers that allow reflecting foreign types
+use bevy_reflect::reflect_remote;
+use valence_bytes::Utf8Bytes;
+use valence_ident::{Ident, ident};
+use valence_protocol::{
+    CompressionThreshold as Threshold,
+    packets::play::command_tree_s2c::{NodeData, Parser, StringArg, Suggestion},
+};
+#[reflect_remote(Threshold)]
+pub struct CompressionThreshold(pub i32);
+
+#[reflect_remote(NodeData)]
+pub enum NodeDataRemote {
+    Root,
+    Literal {
+        #[reflect(ignore)]
+        name: Utf8Bytes,
+    },
+    Argument {
+        #[reflect(ignore)]
+        name: Utf8Bytes,
+        #[reflect(remote = ParserRemote)]
+        parser: Parser,
+        #[reflect(remote = OptionSuggestionRemote)]
+        suggestion: Option<Suggestion>,
+    },
+}
+
+// needed for remotly reflecting parser
+fn default_ident() -> Ident {
+    ident!("minecraft:default")
+}
+
+#[reflect_remote(Parser)]
+pub enum ParserRemote {
+    Bool,
+    Float {
+        min: Option<f32>,
+        max: Option<f32>,
+    },
+    Double {
+        min: Option<f64>,
+        max: Option<f64>,
+    },
+    Integer {
+        min: Option<i32>,
+        max: Option<i32>,
+    },
+    Long {
+        min: Option<i64>,
+        max: Option<i64>,
+    },
+    String(#[reflect(remote=StringArgRemote)] StringArg),
+    Entity {
+        single: bool,
+        only_players: bool,
+    },
+    GameProfile,
+    BlockPos,
+    ColumnPos,
+    Vec3,
+    Vec2,
+    BlockState,
+    BlockPredicate,
+    ItemStack,
+    ItemPredicate,
+    Color,
+    Component,
+    Message,
+    NbtCompoundTag,
+    NbtTag,
+    NbtPath,
+    Objective,
+    ObjectiveCriteria,
+    Operation,
+    Particle,
+    Angle,
+    Rotation,
+    ScoreboardSlot,
+    ScoreHolder {
+        allow_multiple: bool,
+    },
+    Swizzle,
+    Team,
+    ItemSlot,
+    ResourceLocation,
+    Function,
+    EntityAnchor,
+    IntRange,
+    FloatRange,
+    Dimension,
+    GameMode,
+    Time,
+    ResourceOrTag {
+        #[reflect(ignore, default = "default_ident")]
+        registry: Ident,
+    },
+    ResourceOrTagKey {
+        #[reflect(ignore, default = "default_ident")]
+        registry: Ident,
+    },
+    Resource {
+        #[reflect(ignore, default = "default_ident")]
+        registry: Ident,
+    },
+    ResourceKey {
+        #[reflect(ignore, default = "default_ident")]
+        registry: Ident,
+    },
+    TemplateMirror,
+    TemplateRotation,
+    Uuid,
+}
+
+#[reflect_remote(Option<Suggestion>)]
+pub enum OptionSuggestionRemote {
+    None,
+    Some(#[reflect(remote = SuggestionRemote)] Suggestion),
+}
+
+#[reflect_remote(StringArg)]
+pub enum StringArgRemote {
+    SingleWord,
+    QuotablePhrase,
+    GreedyPhrase,
+}
+
+#[reflect_remote(Suggestion)]
+pub enum SuggestionRemote {
+    AskServer,
+    AllRecipes,
+    AvailableSounds,
+    AvailableBiomes,
+    SummonableEntities,
+}
+
+#[must_use]
+pub fn command_permission_default()
+-> fn(world: &bevy_ecs::world::World, caller: bevy_ecs::entity::Entity) -> bool {
+    |_: _, _: _| true
+}
+
+// TODO: This is probably a pretty bad idea, working with this internal representation
+#[reflect_remote(enumset::EnumSet<crate::simulation::animation::Kind>)]
+pub struct EnumSetKindRemote {
+    pub __priv_repr: u8,
+}

--- a/crates/hyperion/src/simulation/animation.rs
+++ b/crates/hyperion/src/simulation/animation.rs
@@ -1,6 +1,8 @@
 use bevy_ecs::component::Component;
 use enumset::{EnumSet, EnumSetType};
 use valence_protocol::{VarInt, packets::play::EntityAnimationS2c};
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 #[derive(EnumSetType)]
 #[repr(u8)]
@@ -14,7 +16,9 @@ pub enum Kind {
 }
 
 #[derive(Component)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct ActiveAnimation {
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     kind: EnumSet<Kind>,
 }
 

--- a/crates/hyperion/src/simulation/animation.rs
+++ b/crates/hyperion/src/simulation/animation.rs
@@ -18,7 +18,7 @@ pub enum Kind {
 #[derive(Component)]
 #[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct ActiveAnimation {
-    #[cfg_attr(feature = "reflect", reflect(ignore))]
+    #[cfg_attr(feature = "reflect", reflect(remote = crate::reflect::EnumSetKindRemote))]
     kind: EnumSet<Kind>,
 }
 

--- a/crates/hyperion/src/simulation/blocks/loader/mod.rs
+++ b/crates/hyperion/src/simulation/blocks/loader/mod.rs
@@ -70,9 +70,7 @@ impl ChunkLoaderHandle {
             tx_load_chunk_requests,
         }
     }
-}
 
-impl ChunkLoaderHandle {
     pub fn send(&self, position: I16Vec2, tx: tokio::sync::mpsc::UnboundedSender<Column>) {
         self.tx_load_chunk_requests
             .send(Message { position, tx })

--- a/crates/hyperion/src/simulation/command.rs
+++ b/crates/hyperion/src/simulation/command.rs
@@ -11,25 +11,19 @@ use valence_protocol::{
 #[cfg(feature = "reflect")]
 use {
     bevy_ecs::reflect::{ReflectComponent, ReflectResource},
-    bevy_reflect::{Reflect, std_traits::ReflectDefault},
+    bevy_reflect::Reflect,
 };
 
 #[derive(Component)]
-#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component, Default))]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Command {
-    #[cfg_attr(feature = "reflect", reflect(ignore))]
+    #[cfg_attr(feature = "reflect", reflect(remote = crate::reflect::NodeDataRemote))]
     data: NodeData,
-    #[cfg_attr(feature = "reflect", reflect(ignore))]
+    #[cfg_attr(
+        feature = "reflect",
+        reflect(ignore, default = "crate::reflect::command_permission_default")
+    )]
     has_permission: fn(world: &World, caller: Entity) -> bool,
-}
-
-impl Default for Command {
-    fn default() -> Self {
-        Self {
-            data: NodeData::Root,
-            has_permission: |_: _, _: _| true,
-        }
-    }
 }
 
 #[derive(Resource)]

--- a/crates/hyperion/src/simulation/command.rs
+++ b/crates/hyperion/src/simulation/command.rs
@@ -8,14 +8,32 @@ use valence_protocol::{
     VarInt,
     packets::play::command_tree_s2c::{Node, NodeData, Parser, Suggestion},
 };
+#[cfg(feature = "reflect")]
+use {
+    bevy_ecs::reflect::{ReflectComponent, ReflectResource},
+    bevy_reflect::{Reflect, std_traits::ReflectDefault},
+};
 
 #[derive(Component)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component, Default))]
 pub struct Command {
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     data: NodeData,
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     has_permission: fn(world: &World, caller: Entity) -> bool,
 }
 
+impl Default for Command {
+    fn default() -> Self {
+        Self {
+            data: NodeData::Root,
+            has_permission: |_: _, _: _| true,
+        }
+    }
+}
+
 #[derive(Resource)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
 pub struct RootCommand(Entity);
 
 impl std::ops::Deref for RootCommand {

--- a/crates/hyperion/src/simulation/entity_kind.rs
+++ b/crates/hyperion/src/simulation/entity_kind.rs
@@ -1,6 +1,9 @@
 use bevy_ecs::component::Component;
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 #[derive(Component, Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 #[repr(C)]
 pub enum EntityKind {
     Allay = 0,

--- a/crates/hyperion/src/simulation/metadata/entity.rs
+++ b/crates/hyperion/src/simulation/metadata/entity.rs
@@ -16,6 +16,8 @@
 use bevy_ecs::component::Component;
 use valence_protocol::{Encode, VarInt};
 use valence_text::Text;
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 use crate::{define_and_register_components, simulation::Metadata};
 
@@ -70,6 +72,7 @@ impl Default for TicksFrozenInPowderSnow {
 
 #[derive(Encode, Clone, Copy, Default, PartialEq, Eq, Debug)]
 #[derive(Component)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 #[repr(C)] // ideally this would be u8
 pub enum Pose {
     #[default]

--- a/crates/hyperion/src/simulation/metadata/entity/flags.rs
+++ b/crates/hyperion/src/simulation/metadata/entity/flags.rs
@@ -1,9 +1,12 @@
 use bevy_ecs::component::Component;
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 use crate::simulation::metadata::Metadata;
 
 // todo: can be u8
 #[derive(Component, PartialEq, Eq, Copy, Clone, Debug)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct EntityFlags {
     value: u8,
 }

--- a/crates/hyperion/src/simulation/metadata/mod.rs
+++ b/crates/hyperion/src/simulation/metadata/mod.rs
@@ -124,12 +124,12 @@ pub trait Metadata {
     fn to_type(self) -> Self::Type;
 }
 
+// TODO: These macros do not play nicely with reflection. What are they used for? Maybe attributes can be added as an extra argument?
 #[macro_export]
 macro_rules! define_metadata_component {
     ($index:literal, $name:ident -> $type:ty) => {
         #[derive(bevy_ecs::component::Component, Clone, PartialEq, Debug)]
         #[allow(clippy::derive_partial_eq_without_eq)]
-        // TODO: Do these need Reflect?
         pub struct $name {
             value: $type,
         }

--- a/crates/hyperion/src/simulation/metadata/mod.rs
+++ b/crates/hyperion/src/simulation/metadata/mod.rs
@@ -11,6 +11,8 @@ use bevy_ecs::{
 use hyperion_utils::{Prev, track_prev};
 use tracing::error;
 use valence_protocol::{Encode, VarInt};
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 use crate::simulation::metadata::entity::{EntityFlags, Pose};
 
@@ -105,6 +107,7 @@ use super::entity_kind::EntityKind;
 use crate::simulation::metadata::r#type::MetadataType;
 
 #[derive(Debug, Default, Component, Clone)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 // index (u8), type (varint), value (varies)
 /// <https://wiki.vg/Entity_metadata>
 ///
@@ -126,6 +129,7 @@ macro_rules! define_metadata_component {
     ($index:literal, $name:ident -> $type:ty) => {
         #[derive(bevy_ecs::component::Component, Clone, PartialEq, Debug)]
         #[allow(clippy::derive_partial_eq_without_eq)]
+        // TODO: Do these need Reflect?
         pub struct $name {
             value: $type,
         }

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -418,7 +418,7 @@ pub struct Position {
     /// Note we are using [`Vec3`] instead of [`glam::DVec3`] because *cache locality* is important.
     /// However, the Notchian server uses double precision floating point numbers for the position.
     #[cfg_attr(feature = "reflect", reflect(ignore))]
-    position: Vec3,
+    position: Vec3, // TODO: Reflect this once glam is updated everywhere
 }
 
 impl Position {
@@ -565,7 +565,7 @@ impl Position {
 #[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct ChunkPosition {
     #[cfg_attr(feature = "reflect", reflect(ignore))]
-    pub position: I16Vec2,
+    pub position: I16Vec2, // TODO: Reflect this once glam is updated everywhere
 }
 
 const SANE_MAX_RADIUS: i16 = 128;
@@ -632,7 +632,7 @@ impl Position {
 /// - Later we can apply the reaction to the entity's [`Position`] to move the entity.
 #[derive(Component, Default, Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
-pub struct Velocity(#[cfg_attr(feature = "reflect", reflect(ignore))] pub Vec3);
+pub struct Velocity(#[cfg_attr(feature = "reflect", reflect(ignore))] pub Vec3); // TODO: Reflect this once glam is updated everywhere
 
 impl Velocity {
     #[must_use]
@@ -651,6 +651,7 @@ impl Velocity {
 pub struct PendingTeleportation {
     pub teleport_id: i32,
     #[cfg_attr(feature = "reflect", reflect(ignore))]
+    // TODO: Reflect this once glam is updated everywhere
     pub destination: Vec3,
     pub ttl: u8,
 }
@@ -691,9 +692,11 @@ pub struct MovementTracking {
     pub fall_start_y: f32,
     pub last_tick_flying: bool,
     #[cfg_attr(feature = "reflect", reflect(ignore))]
+    // TODO: Reflect this once glam is updated everywhere
     pub last_tick_position: Vec3,
     pub received_movement_packets: u8,
     #[cfg_attr(feature = "reflect", reflect(ignore))]
+    // TODO: Reflect this once glam is updated everywhere
     pub server_velocity: DVec3,
     pub sprinting: bool,
     pub was_on_ground: bool,

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -30,6 +30,11 @@ use valence_protocol::{
     },
 };
 use valence_text::IntoText;
+#[cfg(feature = "reflect")]
+use {
+    bevy_ecs::reflect::{ReflectComponent, ReflectResource},
+    bevy_reflect::Reflect,
+};
 
 use crate::{
     Global,
@@ -58,8 +63,10 @@ pub mod skin;
 pub mod util;
 
 #[derive(Resource, Default, Debug)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
 pub struct StreamLookup {
     /// The UUID of all players
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     inner: FxHashMap<u64, Entity>,
 }
 
@@ -78,6 +85,7 @@ impl std::ops::DerefMut for StreamLookup {
 }
 
 #[derive(Component, Default, Debug)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct PlayerUuidLookup {
     /// The UUID of all players
     inner: HashMap<Uuid, Entity>,
@@ -124,7 +132,8 @@ impl std::ops::DerefMut for EgressComm {
 }
 
 #[derive(Resource, Debug, Default)]
-pub struct IgnMap(FxHashMap<String, Entity>);
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
+pub struct IgnMap(#[cfg_attr(feature = "reflect", reflect(ignore))] FxHashMap<String, Entity>);
 
 impl std::ops::Deref for IgnMap {
     type Target = FxHashMap<String, Entity>;
@@ -141,17 +150,20 @@ impl std::ops::DerefMut for IgnMap {
 }
 
 #[derive(Component, Debug, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct RaycastTravel;
 
 /// A component that represents a Player. In the future, this should be broken up into multiple components.
 ///
 /// Why should it be broken up? The more things are broken up, the more we can take advantage of Rust borrowing rules.
 #[derive(Component, Debug, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Player;
 
 #[derive(
     Component, Debug, PartialEq, Eq, PartialOrd, Copy, Clone, Default, Pod, Zeroable
 )]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 #[repr(C)]
 pub struct Xp {
     pub amount: u16,
@@ -308,6 +320,7 @@ impl Xp {
 pub const FULL_HEALTH: f32 = 20.0;
 
 #[derive(Component, Debug, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct ConfirmBlockSequences(pub Vec<i32>);
 
 impl std::ops::Deref for ConfirmBlockSequences {
@@ -325,6 +338,7 @@ impl std::ops::DerefMut for ConfirmBlockSequences {
 }
 
 #[derive(Component, Debug, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 #[expect(missing_docs)]
 pub struct ImmuneStatus {
     /// The tick until the player is immune to player attacks.
@@ -341,6 +355,7 @@ impl ImmuneStatus {
 
 /// A UUID component. Generally speaking, this tends to be tied to entities with a [`Player`] component.
 #[derive(Component, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Uuid(pub uuid::Uuid);
 
 impl Uuid {
@@ -362,10 +377,12 @@ impl std::ops::Deref for Uuid {
 ///
 /// Example: zombie, skeleton, etc.
 #[derive(Component, Debug)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Npc;
 
 /// The running multiplier of the entity. This defaults to 1.0.
 #[derive(Component, Debug, Copy, Clone)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct RunningSpeed(pub f32);
 
 impl Default for RunningSpeed {
@@ -376,6 +393,7 @@ impl Default for RunningSpeed {
 
 // TODO: This might be a good fit for a relationship?
 #[derive(Component)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Owner {
     pub entity: Entity,
 }
@@ -389,14 +407,17 @@ impl Owner {
 
 /// If the entity can be targeted by non-player entities.
 #[derive(Component)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct AiTargetable;
 
 /// The full pose of an entity. This is used for both [`Player`] and [`Npc`].
 #[derive(Component, Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Position {
     /// The (x, y, z) position of the entity.
     /// Note we are using [`Vec3`] instead of [`glam::DVec3`] because *cache locality* is important.
     /// However, the Notchian server uses double precision floating point numbers for the position.
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     position: Vec3,
 }
 
@@ -450,6 +471,7 @@ impl std::ops::DerefMut for Position {
 }
 
 #[derive(Component, Copy, Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Yaw {
     yaw: f32,
 }
@@ -477,6 +499,7 @@ impl std::ops::Deref for Yaw {
 }
 
 #[derive(Component, Copy, Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Pitch {
     pitch: f32,
 }
@@ -507,6 +530,7 @@ const PLAYER_WIDTH: f32 = 0.6;
 const PLAYER_HEIGHT: f32 = 1.8;
 
 #[derive(Component, Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct EntitySize {
     pub half_width: f32,
     pub height: f32,
@@ -538,7 +562,9 @@ impl Position {
 }
 
 #[derive(Component, Debug, Copy, Clone)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct ChunkPosition {
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     pub position: I16Vec2,
 }
 
@@ -605,7 +631,8 @@ impl Position {
 /// - Therefore, we have an [`Velocity`] component which is used to store the reaction of an entity to collisions.
 /// - Later we can apply the reaction to the entity's [`Position`] to move the entity.
 #[derive(Component, Default, Debug, Copy, Clone, PartialEq)]
-pub struct Velocity(pub Vec3);
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
+pub struct Velocity(#[cfg_attr(feature = "reflect", reflect(ignore))] pub Vec3);
 
 impl Velocity {
     #[must_use]
@@ -620,8 +647,10 @@ impl Velocity {
 }
 
 #[derive(Component, Default, Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct PendingTeleportation {
     pub teleport_id: i32,
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     pub destination: Vec3,
     pub ttl: u8,
 }
@@ -638,6 +667,7 @@ impl PendingTeleportation {
 }
 
 #[derive(Component, Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct FlyingSpeed {
     pub speed: f32,
 }
@@ -656,17 +686,21 @@ impl Default for FlyingSpeed {
 }
 
 #[derive(Component, Default, Debug, Copy, Clone)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct MovementTracking {
     pub fall_start_y: f32,
     pub last_tick_flying: bool,
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     pub last_tick_position: Vec3,
     pub received_movement_packets: u8,
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     pub server_velocity: DVec3,
     pub sprinting: bool,
     pub was_on_ground: bool,
 }
 
 #[derive(Component, Default, Debug, Copy, Clone)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Flight {
     pub allow: bool,
     pub is_flying: bool,
@@ -857,6 +891,7 @@ impl Plugin for SimPlugin {
 pub struct RequestSubscribeChannelPackets(pub Entity);
 
 #[derive(Component)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Visible;
 
 #[must_use]

--- a/crates/hyperion/src/simulation/packet_state.rs
+++ b/crates/hyperion/src/simulation/packet_state.rs
@@ -4,18 +4,22 @@
 /// - [`crate::ConnectionId`]
 /// - [`crate::PacketDecoder`]
 use bevy_ecs::component::Component;
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 /// Marks players who are in the handshake state.
 #[derive(Component)]
-pub struct Handshake(pub(crate) ());
-
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
+pub struct Handshake;
 /// Marks players who are in the status state.
 #[derive(Component)]
-pub struct Status(pub(crate) ());
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
+pub struct Status;
 
 /// Marks players who are in the login state.
 #[derive(Component)]
-pub struct Login(pub(crate) ());
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
+pub struct Login;
 
 /// Marks players who are in the play state.
 ///
@@ -30,5 +34,7 @@ pub struct Login(pub(crate) ());
 /// - [`crate::simulation::Pitch`]
 /// - [`crate::simulation::skin::PlayerSkin`]
 /// - [`crate::simulation::Position`]
+/// - [`crate::simulation::Player`]
 #[derive(Component)]
-pub struct Play(pub(crate) ());
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
+pub struct Play;

--- a/crates/hyperion/src/simulation/skin.rs
+++ b/crates/hyperion/src/simulation/skin.rs
@@ -4,6 +4,8 @@ use base64::{Engine as _, engine::general_purpose};
 use bevy_ecs::component::Component;
 use rkyv::Archive;
 use tracing::info;
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 use crate::{storage::SkinHandler, util::mojang::MojangClient};
 
@@ -18,6 +20,7 @@ use crate::{storage::SkinHandler, util::mojang::MojangClient};
     serde::Serialize,
     serde::Deserialize
 )]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct PlayerSkin {
     /// The textures of the player skin, usually obtained from the [`MojangClient`] as a base64 string.
     pub textures: String,

--- a/crates/hyperion/src/spatial/mod.rs
+++ b/crates/hyperion/src/spatial/mod.rs
@@ -10,6 +10,11 @@ use geometry::{aabb::Aabb, ray::Ray};
 use glam::Vec3;
 use ordered_float::NotNan;
 use rayon::iter::Either;
+#[cfg(feature = "reflect")]
+use {
+    bevy_ecs::reflect::{ReflectComponent, ReflectResource},
+    bevy_reflect::Reflect,
+};
 
 use super::simulation::{
     EntitySize, Position, aabb,
@@ -19,8 +24,10 @@ use super::simulation::{
 pub struct SpatialPlugin;
 
 #[derive(Resource, Debug, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
 pub struct SpatialIndex {
     /// The bounding boxes of all entities with the [`Spatial`] component
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     query: bvh_region::Bvh<Entity>,
 }
 
@@ -119,6 +126,7 @@ fn recalculate_spatial_index(
 
 /// If we want the entity to be spatially indexed, we need to add this component.
 #[derive(Component)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Spatial;
 
 impl Plugin for SpatialPlugin {

--- a/crates/hyperion/src/storage/db.rs
+++ b/crates/hyperion/src/storage/db.rs
@@ -3,6 +3,8 @@
 use std::path::Path;
 
 use bevy_ecs::resource::Resource;
+#[cfg(feature = "reflect")]
+use bevy_reflect::Reflect;
 use byteorder::NativeEndian;
 use heed::{Database, Env, EnvOpenOptions, types};
 use uuid::Uuid;
@@ -11,6 +13,7 @@ use crate::simulation::skin::{ArchivedPlayerSkin, PlayerSkin};
 
 /// A wrapper around a `Heed` database
 #[derive(Resource, Debug, Clone)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(opaque))]
 pub struct LocalDb {
     env: Env,
 }
@@ -43,6 +46,7 @@ impl std::ops::Deref for LocalDb {
 
 /// A handler for player skin operations
 #[derive(Resource, Debug, Clone)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(opaque))]
 pub struct SkinHandler {
     env: Env,
     skins: Database<types::U128<NativeEndian>, types::Bytes>,

--- a/crates/packet-channel/Cargo.toml
+++ b/crates/packet-channel/Cargo.toml
@@ -5,6 +5,13 @@ version.workspace = true
 publish = false
 readme = "README.md"
 
+[features]
+reflect = [
+    "dep:bevy_reflect",
+    "bevy_ecs/reflect_auto_register",
+    "bevy_reflect/auto_register_inventory",
+]
+
 [[bench]]
 harness = false
 name = "packet_channel"
@@ -14,6 +21,7 @@ valence_protocol.workspace = true
 
 bevy_ecs.workspace = true
 bevy_platform.workspace = true
+bevy_reflect = { workspace = true, optional = true }
 
 arc-swap.workspace = true
 more-asserts.workspace = true

--- a/crates/packet-channel/src/lib.rs
+++ b/crates/packet-channel/src/lib.rs
@@ -13,9 +13,12 @@ use bevy_ecs::component::Component;
 use bevy_platform::cell::SyncUnsafeCell;
 use more_asserts::debug_assert_le;
 use valence_protocol::MAX_PACKET_SIZE;
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 /// Reference counted fragment. Fragments are a fixed-size block of data which may contain one or
 /// more packets.
+#[derive(Default)]
 struct Fragment {
     /// Points to the next fragment, if available. Once this is set to `Some`, this fragment's `read_cursor` will never be
     /// updated and `next` will never be modified.
@@ -331,8 +334,10 @@ impl Sender {
     }
 }
 
-#[derive(Component)]
+#[derive(Component, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Receiver {
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     current: Arc<Fragment>,
     read_cursor: usize,
 }

--- a/events/bedwars/Cargo.toml
+++ b/events/bedwars/Cargo.toml
@@ -5,6 +5,22 @@ version.workspace = true
 publish = false
 readme = "README.md"
 
+[features]
+reflect = [
+    "dep:bevy_reflect",
+    "bevy_app/reflect_auto_register",
+    "bevy_ecs/reflect_auto_register",
+    "bevy_reflect/auto_register_inventory",
+    "hyperion/reflect",
+    "hyperion-clap/reflect",
+    "hyperion-gui/reflect",
+    "hyperion-inventory/reflect",
+    "hyperion-item/reflect",
+    "hyperion-permission/reflect",
+    "hyperion-proxy-module/reflect",
+    "hyperion-utils/reflect",
+]
+
 [dependencies]
 hyperion.workspace = true
 hyperion-clap.workspace = true
@@ -24,6 +40,12 @@ valence_text.workspace = true
 
 bevy_app.workspace = true
 bevy_ecs.workspace = true
+# this is definitely only a dependency that would be used by projects built on top of hyperion
+bevy_reflect = { workspace = true, optional = true }
+bevy_remote = { version = '0.18', default-features = false, features = [
+    'http',
+] }
+bevy_tasks.workspace = true
 
 anyhow.workspace = true
 clap.workspace = true

--- a/events/bedwars/src/plugin/attack.rs
+++ b/events/bedwars/src/plugin/attack.rs
@@ -33,6 +33,8 @@ use valence_protocol::{
     },
     text::IntoText,
 };
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 use super::spawn::{avoid_blocks, find_spawn_position, is_valid_spawn_block};
 use crate::Team;
@@ -40,12 +42,14 @@ use crate::Team;
 pub struct AttackPlugin;
 
 #[derive(Component, Default, Copy, Clone, Debug)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct ImmuneUntil {
     tick: i64,
 }
 
 // Used as a component only for commands, does not include armor or weapons
 #[derive(Component, Default, Copy, Clone, Debug)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct CombatStats {
     pub armor: f32,
     pub armor_toughness: f32,

--- a/events/bedwars/src/plugin/chat.rs
+++ b/events/bedwars/src/plugin/chat.rs
@@ -18,13 +18,16 @@ use valence_protocol::{
     packets::play,
     text::{Color, IntoText, Text},
 };
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 use crate::Team;
 
 const CHAT_COOLDOWN_SECONDS: i64 = 3; // 3 seconds
 const CHAT_COOLDOWN_TICKS: i64 = CHAT_COOLDOWN_SECONDS * 20; // Convert seconds to ticks
 
-#[derive(Default, Component)]
+#[derive(Component, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct ChatCooldown {
     pub expires: i64,
 }

--- a/events/bedwars/src/plugin/regeneration.rs
+++ b/events/bedwars/src/plugin/regeneration.rs
@@ -10,12 +10,15 @@ use hyperion::{
     simulation::{metadata::living_entity::Health, packet_state},
 };
 use hyperion_utils::Prev;
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 const MAX_HEALTH: f32 = 20.0;
 
 pub struct RegenerationPlugin;
 
 #[derive(Component, Default, Copy, Clone, Debug)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct LastDamaged {
     pub tick: i64,
 }

--- a/events/bedwars/src/plugin/stats.rs
+++ b/events/bedwars/src/plugin/stats.rs
@@ -8,11 +8,15 @@ use bevy_ecs::{
 use hyperion::net::Compose;
 use tracing::info_span;
 use valence_protocol::{packets::play, text::IntoText};
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectResource, bevy_reflect::Reflect};
 
 #[derive(Resource)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
 struct UpdateStart(Instant);
 
 #[derive(Resource)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Resource))]
 struct TicksElapsed(u64);
 
 pub struct StatsPlugin;

--- a/events/bedwars/src/plugin/vanish.rs
+++ b/events/bedwars/src/plugin/vanish.rs
@@ -12,10 +12,13 @@ use hyperion::{
 use tracing::error;
 use valence_protocol::packets::play::{self, player_list_s2c::PlayerListActions};
 use valence_server::GameMode;
+#[cfg(feature = "reflect")]
+use {bevy_ecs::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 pub struct VanishPlugin;
 
-#[derive(Default, Component, Debug)]
+#[derive(Component, Default, Debug)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Vanished(bool);
 
 impl Vanished {


### PR DESCRIPTION
Inspecting the world at runtime requires reflect to be Derived and the types to be registered. As mentioned in #4, this is important for planned logic investigation and rework, as this makes it possible to easily spot oversights and misassumption about the state of the ecs