### PR TITLE
Perf regression fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,6 @@ heed = '0.21'
 bevy_app = '0.18'
 bevy_ecs = { version = '0.18', default-features = false, features = [
     'multi_threaded',
-    'trace',
 ] }
 bevy_platform = '0.18'
 bevy_reflect = '0.18'

--- a/crates/hyperion/Cargo.toml
+++ b/crates/hyperion/Cargo.toml
@@ -16,6 +16,7 @@ reflect = [
     "hyperion-inventory/reflect",
     "hyperion-utils/reflect",
 ]
+ecs_debug = ["bevy_ecs/trace", "bevy_ecs/debug"]
 
 [[bench]]
 harness = false

--- a/events/bedwars/Cargo.toml
+++ b/events/bedwars/Cargo.toml
@@ -20,6 +20,8 @@ reflect = [
     "hyperion-proxy-module/reflect",
     "hyperion-utils/reflect",
 ]
+# This incurs about a 0.2-0.3ms cost on my system - should more crates have this feature?
+debug = ["hyperion/ecs_debug"]
 
 [dependencies]
 hyperion.workspace = true


### PR DESCRIPTION
#1 made ticks about 0.2ms to 0.3ms slower. Turns out it was tracing on bevy_ecs that I enabled while refactoring. Moving this behind a feature flag fixes the issue